### PR TITLE
hack to get semicolon through to API

### DIFF
--- a/lib/api_bridge/helpers.rb
+++ b/lib/api_bridge/helpers.rb
@@ -11,17 +11,13 @@ module ApiBridge
   end
 
   def self.encode url
-    # Split components of URL so we may encode only the query string, index 7
-    components = URI.split(url).map.with_index { |component, i|
-      i != 7 || component == "" ? component : encode_query_params(component)
-    }
-
-    # Assume URLs are hierarchical, i.e. (scheme)://... not opaque (scheme):...
-    url = "#{components[0]}://" << components[1..5].join("")
-    url << "?#{components[7]}" if components[7] != ""
-    url << components[8] if components[8]
-
-    url
+    # Split components of URL so we may encode only the query string
+    request_url, query = url.split("?")
+    if query
+      encoded = encode_query_params(query)
+      request_url << "?#{encoded}"
+    end
+    request_url
   end
 
   def self.escape_values options

--- a/lib/api_bridge/helpers.rb
+++ b/lib/api_bridge/helpers.rb
@@ -2,16 +2,20 @@ require 'uri'
 
 module ApiBridge
 
-  def self.encode_html string
-    return URI.encode(string)
-  end
-
   def self.calculate_page count, rows
     if count && rows
       return (count.to_f/rows.to_i).ceil
     else
       return 1
     end
+  end
+
+  def self.encode url
+    encoded = URI.encode(url)
+    # semicolons are not caught in the above step
+    encoded = encoded.gsub(";", "%3B")
+    # encoded semicolons may accidentally have had the % double encoded
+    encoded.gsub("%253B", "%3B")
   end
 
   def self.escape_values options

--- a/lib/api_bridge/query.rb
+++ b/lib/api_bridge/query.rb
@@ -51,9 +51,7 @@ module ApiBridge
       end
       query_string = query.join("&")
       url = "#{@url}/items?#{query_string}"
-      # TODO apparently things URI.encode uses are deprecated
-      # even though their docs don't mention it guhhhh
-      encoded = URI.encode(url)
+      encoded = ApiBridge.encode(url)
       if ApiBridge.is_url?(encoded)
         return encoded
       else

--- a/lib/api_bridge/version.rb
+++ b/lib/api_bridge/version.rb
@@ -1,5 +1,5 @@
 module ApiBridge
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 
   def self.version
     VERSION

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -3,18 +3,17 @@ require_relative "../lib/api_bridge.rb"
 
 class HelperTest < Minitest::Test
 
-  def test_encode_html
-    # TODO look into why the ampersand and quotation marks are not encoded?
-    unencoded = "this is a 'string' & some stuff"
-    encoded = ApiBridge.encode_html(unencoded)
-    assert_equal encoded, "this%20is%20a%20'string'%20&%20some%20stuff"
-  end
-
   def test_calculate_page
     assert_equal ApiBridge.calculate_page(101, 20), 6
     assert_equal ApiBridge.calculate_page(1, 20), 1
     assert_equal ApiBridge.calculate_page(9, 3), 3
     assert_equal ApiBridge.calculate_page(57, 5), 12
+  end
+
+  def test_encode
+    assert_equal "Cather%3B%20Pound", ApiBridge.encode("Cather; Pound")
+    assert_equal "Cather,%20Pound", ApiBridge.encode("Cather, Pound")
+    assert_equal "Cather%3B%20Pound", ApiBridge.encode("Cather%3B Pound")
   end
 
   def test_escape_values

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -11,9 +11,12 @@ class HelperTest < Minitest::Test
   end
 
   def test_encode
-    assert_equal "Cather%3B%20Pound", ApiBridge.encode("Cather; Pound")
-    assert_equal "Cather,%20Pound", ApiBridge.encode("Cather, Pound")
-    assert_equal "Cather%3B%20Pound", ApiBridge.encode("Cather%3B Pound")
+    fake_url = "http://something.unl.edu/?param="
+
+    assert_equal "#{fake_url}Cather%3B+Pound",
+      ApiBridge.encode("#{fake_url}Cather; Pound")
+    assert_equal "#{fake_url}Cather%2C+Pound",
+      ApiBridge.encode("#{fake_url}Cather, Pound")
   end
 
   def test_escape_values

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -11,12 +11,28 @@ class HelperTest < Minitest::Test
   end
 
   def test_encode
-    fake_url = "http://something.unl.edu/?param="
+    fake_url = "http://something.unl.edu/"
 
-    assert_equal "#{fake_url}Cather%3B+Pound",
-      ApiBridge.encode("#{fake_url}Cather; Pound")
-    assert_equal "#{fake_url}Cather%2C+Pound",
-      ApiBridge.encode("#{fake_url}Cather, Pound")
+    # semicolons
+    assert_equal "#{fake_url}?param=Cather%3B+Pound",
+      ApiBridge.encode("#{fake_url}?param=Cather; Pound")
+    assert_equal "#{fake_url}?param=Cather%2C+Pound",
+      ApiBridge.encode("#{fake_url}?param=Cather, Pound")
+    # multiple types of characters
+    assert_equal "#{fake_url}?f[]=works%7CTitle+%282012%29+Author",
+      ApiBridge.encode("#{fake_url}?f[]=works|Title (2012) Author")
+    # multiple parameters
+    query_in = "f[]=works|Title (1827)&f[]=works|Title2, Author; Author2&q=*"
+    query_out = "f[]=works%7CTitle+%281827%29&f[]=works%7CTitle2%2C+Author%3B+Author2&q=*"
+    assert_equal "#{fake_url}?#{query_out}",
+      ApiBridge.encode("#{fake_url}?#{query_in}")
+    # no parameters
+    assert_equal fake_url, ApiBridge.encode(fake_url)
+  end
+
+  def test_encode_query_params
+    assert_equal "authors=Cather%3B+Pound&f[]=works%7CSomething",
+      ApiBridge.encode_query_params("authors=Cather; Pound&f[]=works|Something")
   end
 
   def test_escape_values
@@ -39,7 +55,7 @@ class HelperTest < Minitest::Test
   end
 
   def test_override_options
-
+    # TODO
   end
 
 end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -16,12 +16,12 @@ class QueryTest < Minitest::Test
   def test_create_items_url
     # basic
     url = @api.create_items_url()
-    assert_equal url, "#{@fake_url}/items?"
+    assert_equal url, "#{@fake_url}/items"
 
     # with f[] and q
     opts = { "f" => ["thing1", "thing2"], "q" => "water" }
     url = @api.create_items_url(opts)
-    assert_equal url, "#{@fake_url}/items?f[]=thing1&f[]=thing2&q=water"
+    assert_equal "#{@fake_url}/items?f[]=thing1&f[]=thing2&q=water", url
 
     # with f[], facet[], start, and num
     opts = {
@@ -30,17 +30,17 @@ class QueryTest < Minitest::Test
       "start" => 21, "num" => 20
     }
     url = @api.create_items_url(opts)
-    assert_equal url, "#{@fake_url}/items?f[]=subcategory%7Cworks&facet[]=title&facet[]=name&start=21&num=20"
+    assert_equal "#{@fake_url}/items?f[]=subcategory%7Cworks&facet[]=title&facet[]=name&start=21&num=20", url
 
     # with nested f[]
     opts = { "f" => ["creator.name|Willa, Cather"] }
     url = @api.create_items_url(opts)
-    assert_equal url, "#{@fake_url}/items?f[]=creator.name%7CWilla,%20Cather"
+    assert_equal "#{@fake_url}/items?f[]=creator.name%7CWilla%2C+Cather", url
 
     # with multiple sorts
     opts = { "sort" => ["title|asc", "name|desc"] }
     url = @api.create_items_url(opts)
-    assert_equal url, "#{@fake_url}/items?sort[]=title%7Casc&sort[]=name%7Cdesc"
+    assert_equal "#{@fake_url}/items?sort[]=title%7Casc&sort[]=name%7Cdesc", url
   end
 
   def test_reset_options


### PR DESCRIPTION
Regardless of whether the api_bridge is receiving a literal semicolon in the options list, or whether it is receiving an encoded (`%3B`) version, make sure that it is sent to the API as `%3B` in order to be recognized as `;`

If we decide to post data to the API instead of via the URL, this could be revisited.

Changes:
- bumps a version of the rails gem
- writes a test for the semicolon step
- removes unused method

Needs to be done (creating issues for these):
- revisit URI library in favor of CGI
- redo syntax throughout gem to match internal CDRH styleguide choices